### PR TITLE
scheduler image according to kubeVersion

### DIFF
--- a/charts/hwameistor/templates/_helpers.tpl
+++ b/charts/hwameistor/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "hwameistor.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/* Return scheduler image tag. */}}
+{{- define "hwameistor.scheduler.tag" -}}
+{{- if (semverCompare "> 1.18-0" (include "hwameistor.kubeVersion" .)) }}
+{{- printf "%s" .Values.scheduler.tag -}}
+{{- else -}}
+{{- printf "%s-%s" .Values.scheduler.tag "kube-pre1.18" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/hwameistor/templates/scheduler-config.yaml
+++ b/charts/hwameistor/templates/scheduler-config.yaml
@@ -10,6 +10,22 @@ metadata:
   name: hwameistor-scheduler-config
   namespace: {{ .Release.Namespace }}
 data:
+{{- if (semverCompare "> 1.18-0" (include "hwameistor.kubeVersion" .)) }}
+  hwameistor-scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: hwameistor-scheduler
+        plugins:
+          filter:
+            enabled:
+            - name: hwameistor-scheduler-plugin
+    leaderElection:
+      leaderElect: true
+      lockObjectName: hwameistor-scheduler
+    clientConnection:
+      kubeconfig: /etc/kubernetes/scheduler.conf 
+{{- else }}
   hwameistor-scheduler-config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1alpha1
     kind: KubeSchedulerConfiguration
@@ -22,3 +38,4 @@ data:
       filter:
         enabled:
           - name: hwameistor-scheduler-plugin
+{{- end -}}

--- a/charts/hwameistor/templates/scheduler.yaml
+++ b/charts/hwameistor/templates/scheduler.yaml
@@ -31,7 +31,7 @@ spec:
         - --leader-elect-resource-name=hwameistor-scheduler
         - --leader-elect-resource-namespace={{ .Release.Namespace}}
         - --config=/etc/hwameistor/hwameistor-scheduler-config.yaml
-        image: {{ .Values.hwameistorImageRegistry}}/{{ .Values.scheduler.imageRepository}}:{{ .Values.scheduler.tag}}
+        image: {{ .Values.hwameistorImageRegistry}}/{{ .Values.scheduler.imageRepository}}:{{ include "hwameistor.scheduler.tag" . }}
         imagePullPolicy: IfNotPresent
         name: hwameistor-kube-scheduler
         resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Deploy the scheduler image **according to the kubernetes version**.

Here is a example when scheduler version is v0.1.4,

##### kubeVersion > 1.18:
```
ghcr/hwameistor/scheduler:v0.1.4
```

##### kubeVersion <= 1.18:
```
ghcr/hwameistor/scheduler:v0.1.4-pre-kube1.18
```

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
