### PR TITLE
refactor: update kubelet root dir(used by sub dir e.x. pods/volumes/p…

### DIFF
--- a/charts/hwameistor/templates/_helpers.tpl
+++ b/charts/hwameistor/templates/_helpers.tpl
@@ -3,6 +3,11 @@
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
 {{- end -}}
 
+{{/* Allow KubeletRootDir to be overridden. */}}
+{{- define "hwameistor.kubeletRootDir" -}}
+  {{- default "/var/lib/kubelet" .Values.kubeletRootDir -}}
+{{- end -}}
+
 {{/* Return scheduler image tag. */}}
 {{- define "hwameistor.scheduler.tag" -}}
 {{- if (semverCompare "> 1.20-0" (include "hwameistor.kubeVersion" .)) }}

--- a/charts/hwameistor/templates/local-disk-manager-csi-controller.yaml
+++ b/charts/hwameistor/templates/local-disk-manager-csi-controller.yaml
@@ -60,6 +60,6 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/disk.hwameistor.io
+            path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/disk.hwameistor.io
             type: DirectoryOrCreate
 {{- end -}}

--- a/charts/hwameistor/templates/local-disk-manager.yaml
+++ b/charts/hwameistor/templates/local-disk-manager.yaml
@@ -24,7 +24,7 @@ spec:
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/disk.hwameistor.io/csi.sock
+            - --kubelet-registration-path={{ template "hwameistor.kubeletRootDir" . }}/plugins/disk.hwameistor.io/csi.sock
           lifecycle:
             preStop:
               exec:
@@ -59,16 +59,16 @@ spec:
           - name: devmount
             mountPath: /dev
           - name: registration-dir
-            mountPath: /var/lib/kubelet/plugins_registry
+            mountPath: {{ template "hwameistor.kubeletRootDir" . }}/plugins_registry
           - name: plugin-dir
-            mountPath: /var/lib/kubelet/plugins
+            mountPath: {{ template "hwameistor.kubeletRootDir" . }}/plugins
             mountPropagation: "Bidirectional"
           - name: pods-mount-dir
-            mountPath: /var/lib/kubelet/pods
+            mountPath: {{ template "hwameistor.kubeletRootDir" . }}/pods
             mountPropagation: "Bidirectional"
           env:
             - name: CSI_ENDPOINT
-              value: unix://var/lib/kubelet/plugins/disk.hwameistor.io/csi.sock
+              value: unix:/{{ template "hwameistor.kubeletRootDir" . }}/plugins/disk.hwameistor.io/csi.sock
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -108,19 +108,19 @@ spec:
           type: Directory
       - name: socket-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/disk.hwameistor.io
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/disk.hwameistor.io
           type: DirectoryOrCreate
       - name: registration-dir
         hostPath:
-          path: /var/lib/kubelet/plugins_registry/
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins_registry/
           type: Directory
       - name: plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins
           type: DirectoryOrCreate
       - name: pods-mount-dir
         hostPath:
-          path: /var/lib/kubelet/pods
+          path: {{ template "hwameistor.kubeletRootDir" . }}/pods
           type: DirectoryOrCreate
       {{- if .Values.localDiskManager.tolerationsOnMaster }}
       tolerations:

--- a/charts/hwameistor/templates/local-storage-csi-controller.yaml
+++ b/charts/hwameistor/templates/local-storage-csi-controller.yaml
@@ -119,7 +119,7 @@ spec:
         operator: Exists
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/lvm.hwameistor.io
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/lvm.hwameistor.io
           type: DirectoryOrCreate
         name: socket-dir
 {{- end -}}		

--- a/charts/hwameistor/templates/local-storage.yaml
+++ b/charts/hwameistor/templates/local-storage.yaml
@@ -24,7 +24,7 @@ spec:
       - args:
         - --v=5
         - --csi-address=/csi/csi.sock
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/lvm.hwameistor.io/csi.sock
+        - --kubelet-registration-path={{ template "hwameistor.kubeletRootDir" . }}/plugins/lvm.hwameistor.io/csi.sock
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -78,7 +78,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         - name: CSI_ENDPOINT
-          value: unix://var/lib/kubelet/plugins/lvm.hwameistor.io/csi.sock
+          value: unix:/{{ template "hwameistor.kubeletRootDir" . }}/plugins/lvm.hwameistor.io/csi.sock
         - name: NODE_ANNOTATION_KEY_STORAGE_IPV4
           value: localstorage.hwameistor.io/storage-ipv4
         image: {{ .Values.hwameistorImageRegistry}}/{{ .Values.localStorage.member.imageRepository}}:{{ .Values.localStorage.member.tag}}
@@ -114,12 +114,12 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /var/lib/kubelet/plugins
+        - mountPath: {{ template "hwameistor.kubeletRootDir" . }}/plugins
           mountPropagation: Bidirectional
           name: plugin-dir
-        - mountPath: /var/lib/kubelet/plugins_registry
+        - mountPath: {{ template "hwameistor.kubeletRootDir" . }}/plugins_registry
           name: registration-dir
-        - mountPath: /var/lib/kubelet/pods
+        - mountPath: {{ template "hwameistor.kubeletRootDir" . }}/pods
           mountPropagation: Bidirectional
           name: pods-mount-dir
         - mountPath: /dev
@@ -151,15 +151,15 @@ spec:
       {{- end }}
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/lvm.hwameistor.io
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins/lvm.hwameistor.io
           type: DirectoryOrCreate
         name: socket-dir
       - hostPath:
-          path: /var/lib/kubelet/plugins
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins
           type: DirectoryOrCreate
         name: plugin-dir
       - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
+          path: {{ template "hwameistor.kubeletRootDir" . }}/plugins_registry/
           type: Directory
         name: registration-dir
       - hostPath:
@@ -171,7 +171,7 @@ spec:
           type: DirectoryOrCreate
         name: host-etc-drbd
       - hostPath:
-          path: /var/lib/kubelet/pods
+          path: {{ template "hwameistor.kubeletRootDir" . }}/pods
           type: DirectoryOrCreate
         name: pods-mount-dir
   updateStrategy:


### PR DESCRIPTION
…lugins/)

<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
Users can customize the location of kubelet root dir directory by setting ***--set kubeletRootDir=<dir_you_want>***

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
